### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/**
+*
+!*/
 !/.gitignore
 !/bower.json
 !/package.json
@@ -10,5 +11,3 @@
 !/release/trNgGrid.min.css
 !/release/trNgGrid.min.js
 !/release/src/
-
-


### PR DESCRIPTION
Currently, when you bower install trNgGrid, the included .gitignore prevents the files in the `release` dir from being checked in to your local repository. This change fixes that.

See : http://stackoverflow.com/questions/9162919/whitelisting-and-subdirectories-in-git/9227991#9227991

Steps to recreate:
1) I `bower install trNgGrid -save` in my repo.
2) I commit all files and push to Github.
3) Colleague pulls my repo from Github

Expected result:
Colleagues copy contains the `bower/trNgGrid/release` folder and its files

Actual result:
Colleagues `/bower/trNgGrid/release` folder and its files are missing. 
Colleague has to run `bower install` to get the files, which she shouldn't have to do.