### PR TITLE
Remove empty rule from trNgGrid.css

### DIFF
--- a/release/src/css/trNgGrid.css
+++ b/release/src/css/trNgGrid.css
@@ -1,6 +1,3 @@
-.tr-ng-grid {
-}
-
 .tr-ng-grid .tr-ng-grid-footer .pagination {
   margin: 0; 
 }


### PR DESCRIPTION
For some reason this empty reason creates a syntax error to Firefox console. It's also unnecessary.